### PR TITLE
支持笔划、偏旁、部首区（带来了新问题）

### DIFF
--- a/wubicodeeditor.py
+++ b/wubicodeeditor.py
@@ -135,7 +135,7 @@ class Application(Frame):
         IRG显示 = ""
         for 某键值 in 常量.IRG键值:
             状态 = ""
-            if (常量.IRG值前缀 + 某键值 + 常量.IRG值后缀) in self.IRG表[Unicode码]:
+            if (Unicode码 in self.IRG表) and ((常量.IRG值前缀 + 某键值 + 常量.IRG值后缀) in self.IRG表[Unicode码]):
                 状态 = "√"
             else:
                 状态 = "×"

--- a/常量.py
+++ b/常量.py
@@ -12,8 +12,7 @@ from collections import OrderedDict
 # 2B820..2CEAF	CJK-E
 # 2CEB0..2EBEF	CJK-F
 # 按码大小范围排序
-源数据文件 = ["CJK-A.txt", "CJK.txt", "CJKCompatibilityIdeographs.txt", "CJK-B.txt", "CJK-C.txt",
-         "CJK-D.txt", "CJK-E.txt", "CJK-F.txt", "CJKCompatibilityIdeographsSupplement.txt", "CJK-G.txt"]
+源数据文件 = ["CJKRadicalsSupplement.txt", "KangxiRadicals.txt", "CJKStrokes.txt", "CJK-A.txt", "CJK.txt", "CJKCompatibilityIdeographs.txt", "CJK-B.txt", "CJK-C.txt", "CJK-D.txt", "CJK-E.txt", "CJK-F.txt", "CJKCompatibilityIdeographsSupplement.txt", "CJK-G.txt"]
 # 暂时只指出导出到一个文件
 修改后文件 = "CJK-所有.txt"
 

--- a/常量.py
+++ b/常量.py
@@ -27,6 +27,7 @@ from collections import OrderedDict
 字体名_方正楷体S = "方正楷体S"
 字体名_方正新楷体S = "方正新楷体S"
 字体名_BabelStoneHan = "BabelStoneHan"
+字体名_NotoSansMonoCJKSC = "NotoSansMonoCJKSC"
 
 字体名_細明體 = "細明體"
 字体名_細明體_HKSCS = "細明體_HKSCS"
@@ -45,6 +46,7 @@ from collections import OrderedDict
     字体名_方正楷体S: "FZKaiS/",
     字体名_方正新楷体S: "FZNewKaiS/",
     字体名_BabelStoneHan: "BabelStoneHan/",
+    字体名_NotoSansMonoCJKSC: "NotoSansMonoCJKSC/",
     字体名_細明體: "MingLiU/",
     字体名_細明體_HKSCS: "MingLiU_HKSCS/",
     字体名_方正楷体T: "FZKaiT/",
@@ -56,7 +58,7 @@ from collections import OrderedDict
 无字体图片 = "images/NoneFontGlyph.gif"
 
 按地区名取字体列表 = OrderedDict([
-    ("中国大陆", [字体名_中易宋体, 字体名_中华书局宋体, 字体名_汉仪字典宋, 字体名_汉仪仿宋, 字体名_方正宋体S, 字体名_方正楷体S, 字体名_方正新楷体S, 字体名_BabelStoneHan]),
+    ("中国大陆", [字体名_中易宋体, 字体名_中华书局宋体, 字体名_汉仪字典宋, 字体名_汉仪仿宋, 字体名_方正宋体S, 字体名_方正楷体S, 字体名_方正新楷体S, 字体名_BabelStoneHan, 字体名_NotoSansMonoCJKSC]),
     ("中国台港澳", [字体名_細明體, 字体名_細明體_HKSCS, 字体名_方正楷体T, 字体名_全字庫正宋體, 字体名_全字庫正楷體]),
     ("日本", [字体名_花園明朝])])
 


### PR DESCRIPTION
```python
$ python3 wubicodeeditor.py 
[128]
[128, 352]
[128, 352, 400]
[128, 352, 400, 6992]
[128, 352, 400, 6992, 27984]
[128, 352, 400, 6992, 27984, 28496]
[128, 352, 400, 6992, 27984, 28496, 71216]
[128, 352, 400, 6992, 27984, 28496, 71216, 75376]
[128, 352, 400, 6992, 27984, 28496, 71216, 75376, 75600]
[128, 352, 400, 6992, 27984, 28496, 71216, 75376, 75600, 81376]
[128, 352, 400, 6992, 27984, 28496, 71216, 75376, 75600, 81376, 88864]
[128, 352, 400, 6992, 27984, 28496, 71216, 75376, 75600, 81376, 88864, 89408]
[128, 352, 400, 6992, 27984, 28496, 71216, 75376, 75600, 81376, 88864, 89408, 94352]
Traceback (most recent call last):
  File "wubicodeeditor.py", line 192, in <module>
    app = Application(master=root)
  File "wubicodeeditor.py", line 16, in __init__
    self.创建控件()
  File "wubicodeeditor.py", line 104, in 创建控件
    self.IRGSource值 = self.创建只读区(细节区, "IRGSource", self.构建IRG显示(当前字符[0]))
  File "wubicodeeditor.py", line 138, in 构建IRG显示
    if (常量.IRG值前缀 + 某键值 + 常量.IRG值后缀) in self.IRG表[Unicode码]:
KeyError: 'U+2E80'
```

看提示及我所知应该是新加的这三个区不在Unihan字源数据库范围内，不知道应该怎么修正了:(